### PR TITLE
Fix Readme, await promise, migrate > 100 entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Contentful will be discontinuing the legacy Workflows version in favour of a new
  1. Download or clone the repository to a local folder
  2. In order for the script to be run correctly, please run in the root project folder:
 ```
-npm install
+npm install .
 ```
 
 ## Usage

--- a/migrate.js
+++ b/migrate.js
@@ -143,7 +143,7 @@ if (tagsFromConfig) {
 if (!tagsFromConfig) {
   action("loading workflows v1 configured tags");
   try {
-    const { parameters } = getWorkflowAppInstallation(cmaClient)
+    const { parameters } = await getWorkflowAppInstallation(cmaClient)
     if (!parameters?.workflowDefinitions?.workflow?.states) {
       throw new Error("No workflow v1 configured for environment.");
     }


### PR DESCRIPTION
- Correct the installation in Readme
- Add await to a promise call that would make the script not work otherwise.
- Pass the getEntries parameters correctly
- Skip the entry if it is archived
- Added commented code to enable republishing of the entry if it was already published (otherwise the state would become chagned)