### PR TITLE
fix: Support migration of more than 100 entries

### DIFF
--- a/models/migrate-workflow-v1-entries.js
+++ b/models/migrate-workflow-v1-entries.js
@@ -37,9 +37,11 @@ export async function processEntriesInBatch(args) {
   totalItemsProcessed = totalItemsProcessed ?? 0;
 
   const entries = await cmaClient.entry.getMany({
-    query: { "metadata.tags.sys.id[in]": tagId },
-    limit: batchSize ?? 100,
-    skip: totalItemsProcessed,
+    query: {
+      "metadata.tags.sys.id[in]": tagId,
+      limit: batchSize ?? 100,
+      skip: totalItemsProcessed,
+    },
   });
   if (entries.items.length === 0) {
     info(`No entries found.`, 6);


### PR DESCRIPTION
When running the migration script, we only migrate 100 entries because we have a typo in our query to get all entries